### PR TITLE
Prettier provenance data

### DIFF
--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -33,15 +33,12 @@ function handleResponseHeader(responseHeader) {
 }
 
 function addEntry(sourceUrl, provId) {
-    const provUrl = provenanceUrl(sourceUrl, provId);
-    const provenanceTabUrl = chrome.runtime.getURL("provenance-tab.html") + "#" + encodeURIComponent(provUrl);
+    // const provUrl = provenanceUrl(sourceUrl, provId);
+    // const provenanceTabUrl = chrome.runtime.getURL("provenance-tab.html") + "#" + encodeURIComponent(provUrl);
+    const provenanceTabUrl = chrome.runtime.getURL("provenance-tab.html") + "#" + encodeURIComponent(provId + ";" + sourceUrl);
     const item = document.createElement("li");
     item.innerHTML = `<a href="${provenanceTabUrl}" target="_blank"><b>${provId}:</b> ${sourceUrl}</a>`;
     responseList.appendChild(item);
-}
-
-function provenanceUrl(sourceUrl, provId) {
-    return new URL(`/prov/${provId}`, sourceUrl).toString();
 }
 
 function toggleProvDisplay() {

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -33,8 +33,10 @@ function handleResponseHeader(responseHeader) {
 }
 
 function addEntry(sourceUrl, provId) {
+    const provUrl = provenanceUrl(sourceUrl, provId);
     const item = document.createElement("li");
-    item.innerHTML = `<a href="${provenanceUrl(sourceUrl, provId)}" target="_blank"><b>${provId}:</b> ${sourceUrl}</a>`;
+    item.innerHTML = `<a href="${provUrl}" target="_blank"><b>${provId}:</b> ${sourceUrl}</a>`;
+    item.children[0].onclick = (e) => openProvenanceDataTab(e, provUrl);
     responseList.appendChild(item);
 }
 
@@ -50,6 +52,12 @@ function toggleProvDisplay() {
         provButton.innerText = '▶ Prov';
         responseList.style.display = 'none';
     }
+}
+
+async function openProvenanceDataTab(e, provUrl) {
+    e.preventDefault();
+    const provData = await (await fetch(provUrl)).json();
+    console.log("Provenance data for ", provUrl, " is:", provData);
 }
 
 provButton.onclick = toggleProvDisplay;

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -34,9 +34,10 @@ function handleResponseHeader(responseHeader) {
 
 function addEntry(sourceUrl, provId) {
     const provUrl = provenanceUrl(sourceUrl, provId);
+    const provenanceTabUrl = chrome.runtime.getURL("provenance-tab.html") + "#" + encodeURIComponent(provUrl);
     const item = document.createElement("li");
-    item.innerHTML = `<a href="${provUrl}" target="_blank"><b>${provId}:</b> ${sourceUrl}</a>`;
-    item.children[0].onclick = (e) => openProvenanceDataTab(e, provUrl);
+    item.innerHTML = `<a href="${provenanceTabUrl}" target="_blank"><b>${provId}:</b> ${sourceUrl}</a>`;
+    // item.children[0].onclick = (e) => openProvenanceDataTab(e, provUrl);
     responseList.appendChild(item);
 }
 

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -37,12 +37,11 @@ function addEntry(sourceUrl, provId) {
     const provenanceTabUrl = chrome.runtime.getURL("provenance-tab.html") + "#" + encodeURIComponent(provUrl);
     const item = document.createElement("li");
     item.innerHTML = `<a href="${provenanceTabUrl}" target="_blank"><b>${provId}:</b> ${sourceUrl}</a>`;
-    // item.children[0].onclick = (e) => openProvenanceDataTab(e, provUrl);
     responseList.appendChild(item);
 }
 
 function provenanceUrl(sourceUrl, provId) {
-    return (sourceUrl + "/").replace(/\/.*/, `/prov/${provId}`);
+    return new URL(`/prov/${provId}`, sourceUrl).toString();
 }
 
 function toggleProvDisplay() {
@@ -53,12 +52,6 @@ function toggleProvDisplay() {
         provButton.innerText = '▶ Prov';
         responseList.style.display = 'none';
     }
-}
-
-async function openProvenanceDataTab(e, provUrl) {
-    e.preventDefault();
-    const provData = await (await fetch(provUrl)).json();
-    console.log("Provenance data for ", provUrl, " is:", provData);
 }
 
 provButton.onclick = toggleProvDisplay;

--- a/Browser Plugin/Display Headers Test/manifest.json
+++ b/Browser Plugin/Display Headers Test/manifest.json
@@ -34,7 +34,9 @@
         "provenance-tab.html",
         "provenance-tab.js"
       ],
-      "extension_ids": []
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ],
   "background": {

--- a/Browser Plugin/Display Headers Test/manifest.json
+++ b/Browser Plugin/Display Headers Test/manifest.json
@@ -28,6 +28,15 @@
       ]
     }
   ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "provenance-tab.html",
+        "provenance-tab.js"
+      ],
+      "extension_ids": []
+    }
+  ],
   "background": {
     "service_worker": "background.js"
   }

--- a/Browser Plugin/Display Headers Test/provenance-tab.html
+++ b/Browser Plugin/Display Headers Test/provenance-tab.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+    <head><title>Provenance Information</title></head>
+    <body>
+        <div id="main"></div>
+        <script src="provenance-tab.js"></script>
+    </body>
+</html>

--- a/Browser Plugin/Display Headers Test/provenance-tab.js
+++ b/Browser Plugin/Display Headers Test/provenance-tab.js
@@ -1,0 +1,4 @@
+console.log("Provenance tab script running!");      //DEBUG
+
+const mainDiv = document.getElementById("main");
+mainDiv.innerText = `The URL is ${document.URL}.`;

--- a/Browser Plugin/Display Headers Test/provenance-tab.js
+++ b/Browser Plugin/Display Headers Test/provenance-tab.js
@@ -6,16 +6,38 @@ const delimPos = provInfo.indexOf(";");
 const provId = provInfo.substring(0, delimPos);
 const sourceUrl = provInfo.substring(delimPos + 1);
 const provUrl = provenanceUrl(sourceUrl, provId);
-mainDiv.innerText = `The URL is ${document.URL} with prov ID ${provId} and source URL ${provUrl}.`;
+mainDiv.innerText = `Loading provenance data for source URL ${provUrl}, provenance ID ${provId}...`;
 
 function provenanceUrl(sourceUrl, provId) {
     return new URL(`/prov/${provId}`, sourceUrl).toString();
 }
 
-async function openProvenanceDataTab(provUrl) {
-    // e.preventDefault();
-    const provData = await (await fetch(provUrl)).json();
-    console.log("Provenance data for ", provUrl, " is:", provData);
+function wrap(elems, topLevel, perItem) {
+    return `<${topLevel}>` + elems.map((e) => `<${perItem}>${e}</${perItem}>`).join("") + `</${topLevel}>`;
 }
 
-openProvenanceDataTab(provUrl);
+function tableHeaderRow(elems) {
+    return wrap(elems, "tr", "th");
+}
+
+function tableRow(elems) {
+    return wrap(elems, "tr", "td");
+}
+
+function renderProvenanceHtml(sourceUrl, provId, provData) {
+    return `<h1>Provenance Information</h1><ul><li><b>Source URL:</b> ${sourceUrl}</li><li><b>Provenance ID:</b> ${provId}</li></ul>` +
+        "<table>" +
+        tableHeaderRow(["Activity Type", "End Time"]) +
+        provData.map((e) => tableRow([e.activities[0].type, e.activities[0].endTime])).join("") +
+        "</table>";
+}
+
+async function openProvenanceDataTab(sourceUrl, provId, provUrl) {
+    const provData = await (await fetch(provUrl)).json();
+    console.log("Provenance data for ", provUrl, " is:", provData);
+
+    mainDiv.innerHTML = renderProvenanceHtml(sourceUrl, provId, provData);
+    document.getElementsByTagName("title")[0].innerText = `Provenance Information for ${provUrl}`;
+}
+
+openProvenanceDataTab(sourceUrl, provId, provUrl);

--- a/Browser Plugin/Display Headers Test/provenance-tab.js
+++ b/Browser Plugin/Display Headers Test/provenance-tab.js
@@ -1,4 +1,13 @@
 console.log("Provenance tab script running!");      //DEBUG
 
 const mainDiv = document.getElementById("main");
-mainDiv.innerText = `The URL is ${document.URL}.`;
+const provUrl = decodeURIComponent(new URL(document.URL).hash).substring(1);
+mainDiv.innerText = `The URL is ${document.URL} with hash ${provUrl}.`;
+
+async function openProvenanceDataTab(provUrl) {
+    // e.preventDefault();
+    const provData = await (await fetch(provUrl)).json();
+    console.log("Provenance data for ", provUrl, " is:", provData);
+}
+
+openProvenanceDataTab(provUrl);

--- a/Browser Plugin/Display Headers Test/provenance-tab.js
+++ b/Browser Plugin/Display Headers Test/provenance-tab.js
@@ -1,8 +1,16 @@
 console.log("Provenance tab script running!");      //DEBUG
 
 const mainDiv = document.getElementById("main");
-const provUrl = decodeURIComponent(new URL(document.URL).hash).substring(1);
-mainDiv.innerText = `The URL is ${document.URL} with hash ${provUrl}.`;
+const provInfo = decodeURIComponent(new URL(document.URL).hash).substring(1);
+const delimPos = provInfo.indexOf(";");
+const provId = provInfo.substring(0, delimPos);
+const sourceUrl = provInfo.substring(delimPos + 1);
+const provUrl = provenanceUrl(sourceUrl, provId);
+mainDiv.innerText = `The URL is ${document.URL} with prov ID ${provId} and source URL ${provUrl}.`;
+
+function provenanceUrl(sourceUrl, provId) {
+    return new URL(`/prov/${provId}`, sourceUrl).toString();
+}
 
 async function openProvenanceDataTab(provUrl) {
     // e.preventDefault();


### PR DESCRIPTION
Clicking on a link in the list of provenance-enriched HTTP requests now opens a tab with a slightly prettier display of the provenance data:

![image](https://github.com/veracitylab/DOM-Instrumentation-to-Display-Provenance-Data/assets/11490991/5dd51edc-8591-4b26-a69d-5b48b8ddef71)
