### PR TITLE
Handle page reloads

### DIFF
--- a/Browser Plugin/Display Headers Test/background.js
+++ b/Browser Plugin/Display Headers Test/background.js
@@ -1,13 +1,10 @@
-let responseHeaders = [];
-
 // Don't send messages to tabs before they are ready; queue them up instead
 let readyTabs = new Set();
 let unreadyQueue = new Map();
 
 function responseUrls(details) {
   if (details.type != null && details.method != null && details.requestId != null){
-    responseHeaders.push(JSON.stringify(details, null, 2));
-    console.log("Seesaw HTTP request: " + JSON.stringify(details));		//DEBUG
+    console.log("Saw HTTP request: " + JSON.stringify(details));		//DEBUG
     if (details.type === 'main_frame') {
       // A top-level frame load means we need to start queueing messages until the page indicates it's ready
       const existingQueue = unreadyQueue.get(details.tabId) ?? []
@@ -15,8 +12,9 @@ function responseUrls(details) {
       unreadyQueue.delete(details.tabId);
       readyTabs.delete(details.tabId);
     }
+
+    sendOrQueue(details.tabId, { type: "responseHeader", details });
   }
-  sendOrQueue(details.tabId, { type: "responseHeader", details });
 }
 
 chrome.webRequest.onHeadersReceived.addListener(

--- a/Browser Plugin/Display Headers Test/background.js
+++ b/Browser Plugin/Display Headers Test/background.js
@@ -8,6 +8,13 @@ function responseUrls(details) {
   if (details.type != null && details.method != null && details.requestId != null){
     responseHeaders.push(JSON.stringify(details, null, 2));
     console.log("Seesaw HTTP request: " + JSON.stringify(details));		//DEBUG
+    if (details.type === 'main_frame') {
+      // A top-level frame load means we need to start queueing messages until the page indicates it's ready
+      const existingQueue = unreadyQueue.get(details.tabId) ?? []
+      console.log("Top-level frame load: Tab previously " + (readyTabs.has(details.tabId) ? "ready" : "not ready") + ". Will drop " + (unreadyQueue.get(details.tabId) ?? []).length + " queued messages.");
+      unreadyQueue.delete(details.tabId);
+      readyTabs.delete(details.tabId);
+    }
   }
   sendOrQueue(details.tabId, { type: "responseHeader", details });
 }

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -33,8 +33,6 @@ function handleResponseHeader(responseHeader) {
 }
 
 function addEntry(sourceUrl, provId) {
-    // const provUrl = provenanceUrl(sourceUrl, provId);
-    // const provenanceTabUrl = chrome.runtime.getURL("provenance-tab.html") + "#" + encodeURIComponent(provUrl);
     const provenanceTabUrl = chrome.runtime.getURL("provenance-tab.html") + "#" + encodeURIComponent(provId + ";" + sourceUrl);
     const item = document.createElement("li");
     item.innerHTML = `<a href="${provenanceTabUrl}" target="_blank"><b>${provId}:</b> ${sourceUrl}</a>`;

--- a/Browser Plugin/Display Headers Test/content.js
+++ b/Browser Plugin/Display Headers Test/content.js
@@ -18,19 +18,9 @@ document.getElementsByTagName("body")[0].appendChild(provenanceDiv);
 chrome.runtime.onMessage.addListener((msg) => {
     console.log("Received message: ", msg);
     if (msg.type === 'responseHeader') {
-        handleResponseHeader(msg.details);
+        addEntry(msg.details.url, msg.details.provId);
     }
 });
-
-function handleResponseHeader(responseHeader) {
-    console.log("handleResponseHeader() got: ", responseHeader);
-    const provHeader = responseHeader.responseHeaders.find((h) => h.name === 'provenance-id');
-    if (provHeader) {
-        addEntry(responseHeader.url, provHeader.value);
-    } else {
-        console.log("Ignoring provenance-free message");
-    }
-}
 
 function addEntry(sourceUrl, provId) {
     const provenanceTabUrl = chrome.runtime.getURL("provenance-tab.html") + "#" + encodeURIComponent(provId + ";" + sourceUrl);


### PR DESCRIPTION
Resolves #8. Also some slight simplification and efficiency work.

Tested manually with rapidfire page reloads: Didn't see any service worker errors, and no queued messages were reported as dropped.