### PR TITLE
Persist state in `chrome.storage` instead of global variables

### DIFF
--- a/browser-extension/chrome/background.js
+++ b/browser-extension/chrome/background.js
@@ -1,8 +1,27 @@
-// Don't send messages to tabs before they are ready; queue them up instead
-let readyTabs = new Set();
-let unreadyQueue = new Map();
+console.log("Background process started!");
 
-function responseUrls(details) {
+// Don't send messages to tabs before they are ready; queue them up instead
+// let readyTabs = new Set();
+// let unreadyQueue = new Map();
+async function getReadyTabs() /*: Set<string> */ {
+  const fromStorage = await chrome.storage.session.get('readyTabs');
+  return new Set(fromStorage?.readyTabs ?? []);
+}
+
+async function setReadyTabs(readyTabs /*: Set<string> */) {
+  await chrome.storage.session.set({ readyTabs: [...readyTabs] }); // Store as array since chrome.storage can't handle Sets
+}
+
+async function getUnreadyQueue() /*: Map<string, string[]> */ {
+  const fromStorage = await chrome.storage.session.get('unreadyQueue');
+  return new Map(fromStorage?.unreadyQueue ? Object.entries(fromStorage?.unreadyQueue) : []);
+}
+
+async function setUnreadyQueue(unreadyQueue /*: Map<string, string[]> */) {
+  await chrome.storage.session.set({ unreadyQueue: Object.fromEntries(unreadyQueue) }); // Store as array of pairs since chrome.storage can't handle Maps
+}
+
+async function responseUrls(details) {
   if (details.type != null && details.method != null && details.requestId != null){
     console.log("Saw HTTP request: " + JSON.stringify(details));		//DEBUG
 
@@ -10,14 +29,18 @@ function responseUrls(details) {
     if (provIdInfo) {
       if (details.type === 'main_frame') {
         // A top-level frame load means we need to start queueing messages until the page indicates it's ready
+        const unreadyQueue = await getUnreadyQueue();
+        const readyTabs = await getReadyTabs();
         const existingQueue = unreadyQueue.get(details.tabId) ?? []
         console.log("Top-level frame load: Tab previously " + (readyTabs.has(details.tabId) ? "ready" : "not ready") + ". Will drop " + (unreadyQueue.get(details.tabId) ?? []).length + " queued messages.");
         unreadyQueue.delete(details.tabId);
+        await setUnreadyQueue(unreadyQueue);
         readyTabs.delete(details.tabId);
+        await setReadyTabs(readyTabs);
       }
   
       // sendOrQueue(details.tabId, { type: "responseHeader", details });
-      sendOrQueue(details.tabId, { type: "responseHeader", details: { url: details.url, provId: provIdInfo.value } });
+      await sendOrQueue(details.tabId, { type: "responseHeader", details: { url: details.url, provId: provIdInfo.value } });
     } else {
       console.log("Ignoring provenance-free message");
     }
@@ -30,34 +53,42 @@ chrome.webRequest.onHeadersReceived.addListener(
   ["responseHeaders"]
 );
 
-chrome.runtime.onMessage.addListener((msg, sender) => {
+chrome.runtime.onMessage.addListener(async (msg, sender) => {
   console.log("Received message: ", msg, " from ", sender);
   if (msg.type === 'ready') {
+    const readyTabs = await getReadyTabs();
     readyTabs.add(sender.tab.id);
-    flushUnreadyQueue(sender.tab.id);
+    await setReadyTabs(readyTabs);
+    await flushUnreadyQueue(sender.tab.id);
   }
 });
 
-function sendOrQueue(tabId, msg) {
+async function sendOrQueue(tabId, msg) {
+  const readyTabs = await getReadyTabs();
   if (readyTabs.has(tabId)) {
     console.log("Sending message immediately to ready tab " + tabId);
     send(tabId, msg);
   } else {
     console.log("Queueing message for non-ready tab " + tabId);
+    const unreadyQueue = await getUnreadyQueue();
     let messages = unreadyQueue.get(tabId) ?? [];
     messages.push(msg);
+    console.log("There are now " + messages.length + " messages in the queue.");
     unreadyQueue.set(tabId, messages);
+    await setUnreadyQueue(unreadyQueue);
   }
 }
 
-function flushUnreadyQueue(tabId) {
-  console.log("Flushing unready queue for newly ready tab " + tabId);
+async function flushUnreadyQueue(tabId) {
+  const unreadyQueue = await getUnreadyQueue();
+  console.log("Flushing " + unreadyQueue.get('' + tabId)?.length + " messages from unready queue for newly ready tab " + tabId);
   for (const msg of unreadyQueue.get(tabId) ?? []) {
     console.log("Sending message to newly ready tab " + tabId);
     send(tabId, msg);
   }
 
   unreadyQueue.delete(tabId);
+  await setUnreadyQueue(unreadyQueue);
 }
 
 function send(tabId, msg) {

--- a/browser-extension/chrome/background.js
+++ b/browser-extension/chrome/background.js
@@ -12,13 +12,13 @@ async function setReadyTabs(readyTabs /*: Set<string> */) {
   await chrome.storage.session.set({ readyTabs: [...readyTabs] }); // Store as array since chrome.storage can't handle Sets
 }
 
-async function getUnreadyQueue() /*: Map<string, string[]> */ {
+async function getUnreadyQueue() /*: Map<number, string[]> */ {
   const fromStorage = await chrome.storage.session.get('unreadyQueue');
-  return new Map(fromStorage?.unreadyQueue ? Object.entries(fromStorage?.unreadyQueue) : []);
+  return new Map(fromStorage?.unreadyQueue ?? []);
 }
 
-async function setUnreadyQueue(unreadyQueue /*: Map<string, string[]> */) {
-  await chrome.storage.session.set({ unreadyQueue: Object.fromEntries(unreadyQueue) }); // Store as array of pairs since chrome.storage can't handle Maps
+async function setUnreadyQueue(unreadyQueue /*: Map<number, string[]> */) {
+  await chrome.storage.session.set({ unreadyQueue: [...unreadyQueue.entries()] }); // Store as array of pairs since chrome.storage can't handle Maps
 }
 
 async function responseUrls(details) {

--- a/browser-extension/chrome/background.js
+++ b/browser-extension/chrome/background.js
@@ -111,62 +111,9 @@ function send(tabId, msg) {
 function appendToPromiseChain(func, name) {
   // promiseChain = promiseChain.then(func);
   promiseChain = promiseChain.then(async () => {
-    // console.log("Running in promise chain: " + name);
+    console.log("Running in promise chain: " + name);
     await func();
-    // console.log("Finished running in promise chain: " + name);
+    console.log("Finished running in promise chain: " + name);
   });
   return promiseChain;
 }
-
-//DEBUG: Everything below here is to stress-test the promiseChain -- to make sure that resolved promises don't leak memory
-var DEBUGstressTestPromiseChainEnabled = true;
-var DEBUGstressTestPromiseChainAppendToChainEnabled = true;
-var DEBUGstressTestPromiseChainLoggingRate = false;
-var DEBUGstressTestPromiseChainPauseMs = 1;
-
-async function DEBUGstressTestPromiseChain(name) {
-  let i = 0;
-  const nPromisesPerIter = 10;
-  console.log(`DEBUGstressTestPromiseChain(${name}) starting with ${nPromisesPerIter} promises per iteration`);
-
-  const work = async () => {
-    for (let j = i; j < i + nPromisesPerIter; ++j) {
-      const func = () => {
-        if (DEBUGstressTestPromiseChainLoggingRate && j % DEBUGstressTestPromiseChainLoggingRate === 0) {
-          console.log(`Stress test '${name} iteration ${j}`);
-        }
-
-        // ++i;
-      };
-
-      if (DEBUGstressTestPromiseChainAppendToChainEnabled) {
-        appendToPromiseChain(func, `Stress test '${name} iteration ${j}`);
-      }
-    }
-
-    await promiseChain;
-    
-    i += nPromisesPerIter;
-  };
-
-  if (DEBUGstressTestPromiseChainPauseMs >= 0) {
-    let intervalFunc = setInterval(async () => {
-      if (!DEBUGstressTestPromiseChainEnabled) {
-        console.log(`Cancelling setInterval() for test '${name}'`);
-        clearInterval(intervalFunc);
-      }
-  
-      await work();
-    }, DEBUGstressTestPromiseChainPauseMs);
-  } else {
-    // Negative value means no pauses at all
-    while (DEBUGstressTestPromiseChainEnabled) {
-      await work();
-    }
-
-    console.log(`DEBUGstressTestPromiseChain(${name}) finishing`);
-  }
-}
-
-DEBUGstressTestPromiseChain('one');
-DEBUGstressTestPromiseChain('two');

--- a/browser-extension/chrome/background.js
+++ b/browser-extension/chrome/background.js
@@ -1,24 +1,27 @@
 console.log("Background process started!");
 
+// Used to sequence loads and stores to avoid races
+let promiseChain = Promise.resolve();
+
 // Don't send messages to tabs before they are ready; queue them up instead
 // let readyTabs = new Set();
 // let unreadyQueue = new Map();
 async function getReadyTabs() /*: Set<string> */ {
-  const fromStorage = await chrome.storage.session.get('readyTabs');
+  const fromStorage = await appendToPromiseChain(() => chrome.storage.session.get('readyTabs'));
   return new Set(fromStorage?.readyTabs ?? []);
 }
 
 async function setReadyTabs(readyTabs /*: Set<string> */) {
-  await chrome.storage.session.set({ readyTabs: [...readyTabs] }); // Store as array since chrome.storage can't handle Sets
+  await appendToPromiseChain(() => chrome.storage.session.set({ readyTabs: [...readyTabs] })); // Store as array since chrome.storage can't handle Sets
 }
 
 async function getUnreadyQueue() /*: Map<number, string[]> */ {
-  const fromStorage = await chrome.storage.session.get('unreadyQueue');
+  const fromStorage = await appendToPromiseChain(() => chrome.storage.session.get('unreadyQueue'));
   return new Map(fromStorage?.unreadyQueue ?? []);
 }
 
 async function setUnreadyQueue(unreadyQueue /*: Map<number, string[]> */) {
-  await chrome.storage.session.set({ unreadyQueue: [...unreadyQueue.entries()] }); // Store as array of pairs since chrome.storage can't handle Maps
+  await appendToPromiseChain(() => chrome.storage.session.set({ unreadyQueue: [...unreadyQueue.entries()] })); // Store as array of pairs since chrome.storage can't handle Maps
 }
 
 async function responseUrls(details) {
@@ -29,18 +32,20 @@ async function responseUrls(details) {
     if (provIdInfo) {
       if (details.type === 'main_frame') {
         // A top-level frame load means we need to start queueing messages until the page indicates it's ready
-        const unreadyQueue = await getUnreadyQueue();
-        const readyTabs = await getReadyTabs();
-        const existingQueue = unreadyQueue.get(details.tabId) ?? []
-        console.log("Top-level frame load: Tab previously " + (readyTabs.has(details.tabId) ? "ready" : "not ready") + ". Will drop " + (unreadyQueue.get(details.tabId) ?? []).length + " queued messages.");
-        unreadyQueue.delete(details.tabId);
-        await setUnreadyQueue(unreadyQueue);
-        readyTabs.delete(details.tabId);
-        await setReadyTabs(readyTabs);
+        await appendToPromiseChain(async () => {
+          const unreadyQueue = await getUnreadyQueue();
+          const readyTabs = await getReadyTabs();
+          const existingQueue = unreadyQueue.get(details.tabId) ?? []
+          console.log("Top-level frame load: Tab previously " + (readyTabs.has(details.tabId) ? "ready" : "not ready") + ". Will drop " + (unreadyQueue.get(details.tabId) ?? []).length + " queued messages.");
+          unreadyQueue.delete(details.tabId);
+          await setUnreadyQueue(unreadyQueue);
+          readyTabs.delete(details.tabId);
+          await setReadyTabs(readyTabs);
+        });
       }
   
       // sendOrQueue(details.tabId, { type: "responseHeader", details });
-      await sendOrQueue(details.tabId, { type: "responseHeader", details: { url: details.url, provId: provIdInfo.value } });
+      await appendToPromiseChain(() => sendOrQueue(details.tabId, { type: "responseHeader", details: { url: details.url, provId: provIdInfo.value } }));
     } else {
       console.log("Ignoring provenance-free message");
     }
@@ -56,10 +61,12 @@ chrome.webRequest.onHeadersReceived.addListener(
 chrome.runtime.onMessage.addListener(async (msg, sender) => {
   console.log("Received message: ", msg, " from ", sender);
   if (msg.type === 'ready') {
-    const readyTabs = await getReadyTabs();
-    readyTabs.add(sender.tab.id);
-    await setReadyTabs(readyTabs);
-    await flushUnreadyQueue(sender.tab.id);
+    await appendToPromiseChain(async () => {
+      const readyTabs = await getReadyTabs();
+      readyTabs.add(sender.tab.id);
+      await setReadyTabs(readyTabs);
+      await flushUnreadyQueue(sender.tab.id);
+    });
   }
 });
 
@@ -93,4 +100,9 @@ async function flushUnreadyQueue(tabId) {
 
 function send(tabId, msg) {
   chrome.tabs.sendMessage(tabId, msg);
+}
+
+function appendToPromiseChain(func) {
+  promiseChain = promiseChain.then(func);
+  return promiseChain;
 }


### PR DESCRIPTION
Will resolve #10.

Quite a big refactor, since `chrome.storage` is an async API, which forces most things to become async too.