### PR TITLE
Show entities associated with HTTP request activities

### DIFF
--- a/browser-extension/chrome/injected-early-into-main-world.js
+++ b/browser-extension/chrome/injected-early-into-main-world.js
@@ -84,7 +84,8 @@ window.XMLHttpRequest = class XMLHttpRequest {
           // Modify the response string
           // `this` doesn't work inside an object, use `instance` instead
         //   return instance._XMLHttpRequestInstance.responseText.replace("Barbarian", "IT WORKED!")
-        return instance._XMLHttpRequestInstance.responseText.replace('"title":"', '"title":"IT WORKED!')
+        // return instance._XMLHttpRequestInstance.responseText.replace('"title":"', '"title":"IT WORKED!')
+        return instance._XMLHttpRequestInstance.responseText;
 
           // Or return whatever you want
           return "whatever you wanted"

--- a/browser-extension/chrome/provenance-tab.html
+++ b/browser-extension/chrome/provenance-tab.html
@@ -1,6 +1,31 @@
 <!DOCTYPE html>
 <html>
-    <head><title>Provenance Information</title></head>
+    <head><title>Provenance Information</title>
+        <style>
+            tbody tr:nth-child(odd) {
+                background-color: #BBBBBB;
+            }
+
+            tbody tr:nth-child(even) {
+                background-color: #DDDDDD;
+            }
+
+            th {
+                color: white;
+                background-color: darkblue;
+                font-weight: bold;
+                padding: 5px;
+            }
+
+            td {
+                padding: 5px;
+            }
+
+            pre {
+                margin: auto;
+            }
+        </style>
+    </head>
     <body>
         <div id="main"></div>
         <script src="provenance-tab.js"></script>

--- a/browser-extension/chrome/provenance-tab.js
+++ b/browser-extension/chrome/provenance-tab.js
@@ -25,7 +25,7 @@ function tableRow(elems) {
 }
 
 function renderHttpRequestApacheGet(httpRequestApacheGet) {
-    return "<pre>GET " + httpRequestApacheGet.value + "</pre>";
+    return `<pre style="color: #FF0000; font-weight: bold">GET ` + httpRequestApacheGet.value + "</pre>";
 }
 
 const entityHandlers = {
@@ -33,7 +33,7 @@ const entityHandlers = {
 };
 
 function renderAssociatedEntities(entities) {
-    return wrap(entities.map((e) => e.type in entityHandlers ? entityHandlers[e.type](e) : `Unrecognised entity of type ${e.type} created using ${e.value}`), 'ul', 'li');
+    return entities.map((e) => e.type in entityHandlers ? entityHandlers[e.type](e) : `Unrecognised entity of type ${e.type} created using ${e.value}`).join("<br />");
 }
 
 function renderProvenanceHtml(sourceUrl, provId, provData) {

--- a/browser-extension/chrome/provenance-tab.js
+++ b/browser-extension/chrome/provenance-tab.js
@@ -24,11 +24,23 @@ function tableRow(elems) {
     return wrap(elems, "tr", "td");
 }
 
+function renderHttpRequestApacheGet(httpRequestApacheGet) {
+    return "<pre>GET " + httpRequestApacheGet.value + "</pre>";
+}
+
+const entityHandlers = {
+    HttpRequestApacheGet: renderHttpRequestApacheGet
+};
+
+function renderAssociatedEntities(entities) {
+    return wrap(entities.map((e) => e.type in entityHandlers ? entityHandlers[e.type](e) : `Unrecognised entity of type ${e.type} created using ${e.value}`), 'ul', 'li');
+}
+
 function renderProvenanceHtml(sourceUrl, provId, provData) {
     return `<h1>Provenance Information</h1><ul><li><b>Source URL:</b> ${sourceUrl}</li><li><b>Provenance ID:</b> ${provId}</li></ul>` +
         "<table>" +
-        tableHeaderRow(["Activity Type", "End Time"]) +
-        provData.map((e) => tableRow([e.activities[0].type, e.activities[0].endTime])).join("") +
+        tableHeaderRow(["Activity Type", "End Time", "Associated Data"]) +
+        provData.map((e) => tableRow([e.activities[0].type, e.activities[0].endTime, renderAssociatedEntities(e.associatedEntities)])).join("") +
         "</table>";
 }
 


### PR DESCRIPTION
Shows Apache `HttpGet` requests in a new "Associated Data" column of the provenance info table:

![image](https://github.com/veracitylab/DOM-Instrumentation-to-Display-Provenance-Data/assets/11490991/b3c6959c-3c1c-4471-83fc-476a3a5cee7e)

Also slightly improves how the table looks, and removes "IT WORKS!" from the movie detail panel.